### PR TITLE
Turned off no-unused-variable Lint warning

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,7 @@
   "rules": {
     "no-duplicate-variable": true,
     "no-unused-variable": [
-      true
+      false
     ]
   },
   "rulesDirectory": [


### PR DESCRIPTION
@kamaulynder can you review this small pull request to turn off unused variable Lint warning?

Looks like there's a bug in Ionic that is showing variables are un-used when they are actually being used, so just turning off that warning for now so it doesn't populate the CodeShip builds.