### PR TITLE
Fixed LocationProvider on Android for ushahidi/tenfour-mobile#266

### DIFF
--- a/src/providers/location/location.ts
+++ b/src/providers/location/location.ts
@@ -84,7 +84,7 @@ export class LocationProvider {
 
   public lookupAddress(location:Location):Promise<string> {
     return new Promise((resolve, reject) => {
-        this.logger.info(this, "loadAddress");
+      this.logger.info(this, "loadAddress");
       if (this.platform.is("cordova")) {
         this.geocoder.reverseGeocode(location.latitude, location.longitude).then((results:NativeGeocoderReverseResult[]) => {
           this.logger.info(this, "loadAddress", location, results);


### PR DESCRIPTION
#### Reviewer
@mackers can you review the change to `LocationProvider` for Android?

#### Description
- refactored `LocationProvider` to handle both `array` and `object` from `this.geocoder.reverseGeocode` on Android

#### Related Issues
- ushahidi/tenfour-mobile#266

#### Type Of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Testing related
- [ ] Style improvements
- [ ] Documentation updates
- [ ] Other changes

#### Reviewer Checklist

- [ ] Code compiles in the local environment
- [ ] Code runs successfully in the local environment
- [ ] Code changes address the related issues
- [ ] Code follows project style and naming conventions
- [ ] New and existing tests pass locally with the changes
- [ ] Any suggested changes commented inline on files
- [ ] Code changes can be merged without conflict
