### PR TITLE
Error handling for marking notifications as read for ushahidi/tenfour#1418

### DIFF
--- a/src/pages/notification-list/notification-list.ts
+++ b/src/pages/notification-list/notification-list.ts
@@ -155,18 +155,19 @@ export class NotificationListPage extends BasePrivatePage {
   private viewNotifications() {
     this.logger.info(this, "viewNotifications");
     let promises = [];
-
     for (let notification of this.notifications) {
       if (!notification.read_at) {
         promises.push(this.api.markNotificationAsRead(this.organization, this.user, notification));
       }
-
       notification.viewed_at = new Date();
     }
-
     this.storage.saveNotifications(this.organization, this.notifications).then((saved:boolean) => {
       Promise.all(promises).then(() => {
         this.logger.info(this, "viewNotifications", "Saved", saved);
+        this.events.publish(EVENT_NOTIFICATIONS_CHANGED);
+      },
+      (error:any) => {
+        this.logger.warn(this, "viewNotifications", "Failed", error);
         this.events.publish(EVENT_NOTIFICATIONS_CHANGED);
       });
     });

--- a/src/providers/api/api.ts
+++ b/src/providers/api/api.ts
@@ -1010,22 +1010,21 @@ export class ApiProvider extends HttpProvider {
     return new Promise((resolve, reject) => {
       this.getToken(organization).then((token:Token) => {
         let url = `${this.api}/api/v1/organizations/${organization.id}/people/${user.id}/notifications/${notification.id}`;
-        let params = {
-        };
+        let params = { };
         this.httpPut(url, params, token.access_token).then((data:any) => {
           if (data && data.notification) {
             resolve(true);
           }
           else {
-            reject("Notification Not Updated");
+            resolve(false);
           }
         },
         (error:any) => {
-          reject(error);
+          resolve(false);
         });
       },
       (error:any) => {
-        reject(error);
+        resolve(false);
       });
     });
   }
@@ -1043,7 +1042,7 @@ export class ApiProvider extends HttpProvider {
             resolve(true);
           }
           else {
-            reject("Notifications Not Updated");
+            resolve(false);
           }
         },
         (error:any) => {


### PR DESCRIPTION
#### Reviewer
@mackers can you review this change for marking notifications as read?

#### Description
- error handling in page for marking notifications as viewed
- resolve boolean rather than throwing exception from API

#### Related Issues
- ushahidi/tenfour#1418

#### Type Of Changes
- [X] Bug fix
- [ ] New feature
- [ ] Testing related
- [ ] Style improvements
- [ ] Documentation updates
- [ ] Other changes

#### Reviewer Checklist

- [ ] Code compiles in the local environment
- [ ] Code runs successfully in the local environment
- [ ] Code changes address the related issues
- [ ] Code follows project style and naming conventions
- [ ] New and existing tests pass locally with the changes
- [ ] Any suggested changes commented inline on files
- [ ] Code changes can be merged without conflict
