### PR TITLE
Updated hooks for ushahidi/tenfour-mobile#341

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ ionic cordova platform rm browser
 #### Add Platforms
 ```
 ionic cordova platform add ios --buildConfig=build.json
-ionic cordova platform add android --buildConfig=build.json
+ionic cordova platform add android@6.4.0 --buildConfig=build.json
 ionic cordova platform add browser
 ```
 #### Debug iOS
@@ -87,6 +87,7 @@ ENV=prod ionic cordova build ios --prod --release --buildConfig=build.json
 ```
 #### Release Android
 ```
+sdkmanager --update
 ENV=prod ionic cordova prepare android --prod --release --buildConfig=build.json
 ENV=prod ionic cordova build android --device --prod --release --buildConfig=build.json
 ```

--- a/hooks/after_build/010_meta_files.js
+++ b/hooks/after_build/010_meta_files.js
@@ -10,19 +10,20 @@ function puts(error, stdout, stderr) {
   console.log(stdout);
 }
 
-function removeMetaFiles() {
-  process.stdout.write('removeMetaFiles');
-  var apk = "platforms/android/app/build/outputs/apk/release/app-release.apk";
+function removeMetaFiles(apk) {
   if (fs.existsSync(root + "/" + apk)) {
+    process.stdout.write("removeMetaFiles APK " + apk + " cleaning..." + '\n');
     var command = "zip -d " + apk + " META-INF/\*";
     process.stdout.write(command);
     exec(command, puts);
+    process.stdout.write("removeMetaFiles APK " + apk + " cleaned" + '\n');
   }
   else {
-    process.stdout.write("removeMetaFiles APK " + apk + " does not exist");
+    process.stdout.write("removeMetaFiles APK " + apk + " not found" + '\n');
   }
 }
 
 if (platform === 'android') {
-  removeMetaFiles();
+  removeMetaFiles("platforms/android/build/outputs/apk/release/android-release.apk");
+  removeMetaFiles("platforms/android/app/build/outputs/apk/release/app-release.apk");
 }

--- a/hooks/after_build/020_jar_signer.js
+++ b/hooks/after_build/020_jar_signer.js
@@ -10,10 +10,9 @@ function puts(error, stdout, stderr) {
   console.log(stdout);
 }
 
-function runJarSigner() {
-  process.stdout.write('runJarSigner');
-  var apk = "platforms/android/app/build/outputs/apk/release/app-release.apk";
+function runJarSigner(apk) {
   if (fs.existsSync(root + "/" + apk)) {
+    process.stdout.write("runJarSigner APK " + apk + " signing..." + '\n');
     var json = root + "/build.json";
     if (fs.existsSync(json)) {
       var build = require(json);
@@ -24,16 +23,18 @@ function runJarSigner() {
       var command = "jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore " + keystore + " -storepass " + storePassword + " -keypass " + password + " " + apk + " " + alias;
       process.stdout.write(command);
       exec(command, puts);
+      process.stdout.write("runJarSigner APK " + apk + " signed" + '\n');
     }
     else {
-      process.stdout.write("runJarSigner File " + json + " does not exist");
+      process.stdout.write("runJarSigner File " + json + " not found" + '\n');
     }
   }
   else {
-    process.stdout.write("runJarSigner APK " + apk + " does not exist");
+    process.stdout.write("runJarSigner APK " + apk + " not found" + '\n');
   }
 }
 
 if (platform === 'android') {
-  runJarSigner();
+  runJarSigner("platforms/android/app/build/outputs/apk/release/app-release.apk");
+  runJarSigner("platforms/android/build/outputs/apk/release/android-release.apk");
 }

--- a/hooks/after_build/030_zip_align.js
+++ b/hooks/after_build/030_zip_align.js
@@ -10,21 +10,20 @@ function puts(error, stdout, stderr) {
   console.log(stdout);
 }
 
-function runZipAlign() {
-  process.stdout.write('runZipAlign');
-  var input = "platforms/android/app/build/outputs/apk/release/app-release.apk";
-  var output = "platforms/android/app/build/outputs/apk/release/TenFour.apk";
+function runZipAlign(input, output) {
   if (fs.existsSync(root + "/" + input)) {
+    process.stdout.write("runZipAlign" + input + " aligning..." + '\n');
     var command = "./zipalign -f -v 4 " + input + " " + output;
     process.stdout.write(command);
     exec(command, puts);
-    process.stdout.write("runZipAlign APK " + output + " aligned");
+    process.stdout.write("runZipAlign APK " + output + " aligned" + '\n');
   }
   else {
-    process.stdout.write("runZipAlign APK " + input + " does not exist");
+    process.stdout.write("runZipAlign APK " + input + " not found" + '\n');
   }
 }
 
 if (platform === 'android') {
-  runZipAlign();
+  runZipAlign("platforms/android/build/outputs/apk/release/android-release.apk", "platforms/android/build/outputs/apk/release/TenFour.apk");
+  runZipAlign("platforms/android/app/build/outputs/apk/release/app-release.apk", "platforms/android/app/build/outputs/apk/release/TenFour.apk");
 }


### PR DESCRIPTION
@mackers I ran into an issue building the apps yesterday, the output APK path has changed in latest Android, however found I still needed to use previous version of Android. 

So I updated the hooks to handle both old and latest path formats, can you review?