### PR TITLE
Add default value for starts_at

### DIFF
--- a/src/providers/api/api.ts
+++ b/src/providers/api/api.ts
@@ -869,6 +869,8 @@ export class ApiProvider extends HttpProvider {
         let local = new Date(checkin.schedule.starts_at);
         let utc = new Date(local.getTime() + local.getTimezoneOffset() * 60000);
         params['schedule']['starts_at'] = utc.toISOString();
+      } else {
+        params['schedule']['starts_at'] = new Date().toISOString();
       }
       if (checkin.schedule.expires_at && checkin.schedule.expires_at.length > 0) {
         let local = new Date(checkin.schedule.expires_at);


### PR DESCRIPTION
- I had incorrectly  removed this while making a different fix. Bringing it back for this scenario only ("right now" with recurring checkin) 