### PR TITLE
Call resizeContent after adding people to checkin

### DIFF
--- a/src/pages/checkin-send/checkin-send.html
+++ b/src/pages/checkin-send/checkin-send.html
@@ -82,7 +82,7 @@
                  [(ngModel)]="checkin.schedule.remaining_count" (ngModelChange)="countsChanged($event)"></ion-input>
     </ion-item>
   </ion-list>
-  <ion-list *ngIf="organization && checkin">
+  <ion-list *ngIf="checkin">
     <ion-item>
       <ion-label>Save this check-in to re-use later</ion-label>
       <ion-checkbox checked="false" item-end [(ngModel)]="checkin.template"></ion-checkbox>

--- a/src/pages/checkin-send/checkin-send.ts
+++ b/src/pages/checkin-send/checkin-send.ts
@@ -261,6 +261,7 @@ export class CheckinSendPage extends BasePrivatePage {
          this.checkin.everyone = true;
        }
        this.countRecipients();
+       this.resizeContent();
      });
   }
 


### PR DESCRIPTION
@mackers I triggered a `resizeContent` after adding people to checkin to ensure `Save check-in to re-use later check-box disappears on check-in creation modal` is not below the toolbar, can you review?